### PR TITLE
Correct copy/paste failures

### DIFF
--- a/content/docs/configuration/advanced/airgap-configuration.md
+++ b/content/docs/configuration/advanced/airgap-configuration.md
@@ -61,7 +61,7 @@ Make sure you can access all the files in `os-services` and `releases.yml` by UR
 In your cloud-config, set `burmilla.repositories.core.url` and `burmilla.upgrade.url` to your own `os-services` and `releases` URLs:
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   repositories:
     core:
       url: https://foo.bar.com/os-services
@@ -109,7 +109,7 @@ write_files:
       n/1ZWdSeZPAgjkha5MTUw3o1hjo/0H0ekI4erZFrZnG2N3lDaqDPR8djR+x7Gv6E
       vloANkUoc1pvzvxKoz2HIHUKf+xFT50xppx6wsQZ01pNMSNF0qgc1vvH
       -----END CERTIFICATE-----
-burmilla:
+rancher:
   environment:
     REGISTRY_DOMAIN: xxxx.yyy
   repositories:

--- a/content/docs/configuration/advanced/disable-access-to-system.md
+++ b/content/docs/configuration/advanced/disable-access-to-system.md
@@ -23,7 +23,7 @@ Alternatively, you can set it up in your cloud-config so it's automatically disa
 
 ```yaml
 # cloud-config
-burmilla:
+rancher:
   disable:
   - password
   - autologin

--- a/content/docs/configuration/advanced/resizing-device-partition.md
+++ b/content/docs/configuration/advanced/resizing-device-partition.md
@@ -11,7 +11,7 @@ Once the partition has been resized to fill the device, a `/var/lib/burmilla/res
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   resize_device: /dev/sda
 ```
 

--- a/content/docs/configuration/advanced/running-commands.md
+++ b/content/docs/configuration/advanced/running-commands.md
@@ -22,7 +22,7 @@ When using `runcmd`, BurmillaOS will wait for all commands to complete before st
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
 write_files:
   - path: /etc/rc.local
     permissions: "0755"

--- a/content/docs/configuration/advanced/sysctl.md
+++ b/content/docs/configuration/advanced/sysctl.md
@@ -9,7 +9,7 @@ The `burmilla.sysctl` cloud-config key can be used to control sysctl parameters.
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   sysctl:
     net.ipv4.conf.default.rp_filter: 1
 ```

--- a/content/docs/configuration/base/_index.md
+++ b/content/docs/configuration/base/_index.md
@@ -69,7 +69,7 @@ To output and review the current configuration state you can use the `ros config
 
 ```shell
 $ sudo ros config export
-burmilla:
+rancher:
   docker:
     tls: true
   network:

--- a/content/docs/configuration/base/ssh-keys.md
+++ b/content/docs/configuration/base/ssh-keys.md
@@ -27,7 +27,7 @@ Please note that OpenSSH 7.0 and greater similarly disable the ssh-dss (DSA) pub
 BurmillaOS supports changing the sshd port and IP, you can use these in the cloud-config file:
 
 ```yaml
-burmilla:
+rancher:
   ssh:
     port: 10022
     listen_address: 172.22.100.100

--- a/content/docs/configuration/base/switching-consoles.md
+++ b/content/docs/configuration/base/switching-consoles.md
@@ -21,7 +21,7 @@ Here is an example cloud-config file that can be used to enable the debian conso
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   console: debian
 ```
 

--- a/content/docs/configuration/docker/_index.md
+++ b/content/docs/configuration/docker/_index.md
@@ -13,7 +13,7 @@ In your cloud-config, Docker configuration is located under the `burmilla.docker
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   docker:
     tls: true
     tls_args:
@@ -76,7 +76,7 @@ The following example can be used to set MTU on the Docker daemon:
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   docker:
     extra_args: [--mtu, 1460]
 ```
@@ -95,7 +95,7 @@ In your cloud-config, System Docker configuration is located under the `burmilla
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   system_docker:
     storage_driver: overlay
 ```
@@ -121,7 +121,7 @@ e.g. [BURMILLA_OEM partition](/docs/storage/custom-partition-layout#BURMILLA_OEM
 
 ```
 #cloud-config
-burmilla:
+rancher:
   defaults:
     system_docker_logs: /usr/share/ros/oem/system-docker.log
 ```
@@ -132,7 +132,7 @@ There are 3 Docker engines that can be configured to use the pull-through Docker
 
 ```
 #cloud-config
-burmilla:
+rancher:
   bootstrap_docker:
     registry_mirror: "http://10.10.10.23:5555"
   docker:

--- a/content/docs/configuration/docker/private-registries.md
+++ b/content/docs/configuration/docker/private-registries.md
@@ -10,7 +10,7 @@ For example, to add authentication for DockerHub:
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   registry_auths:
     https://index.docker.io/v1/:
       auth: dXNlcm5hbWU6cGFzc3dvcmQ=
@@ -32,7 +32,7 @@ Alternatively, a username and password can be specified directly.
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   registry_auths:
     https://index.docker.io/v1/:
       username: username

--- a/content/docs/configuration/docker/switching-docker-versions.md
+++ b/content/docs/configuration/docker/switching-docker-versions.md
@@ -25,7 +25,7 @@ BurmillaOS supports defining which Docker engine to use through the cloud-config
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   docker:
     engine: docker-19.03.13
 ```
@@ -98,7 +98,7 @@ All of the previously mentioned methods of switching Docker engines are now avai
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   docker:
     engine: https://myservicefile
 ```

--- a/content/docs/configuration/kernel/loading-kernel-modules.md
+++ b/content/docs/configuration/kernel/loading-kernel-modules.md
@@ -21,7 +21,7 @@ Or
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   modules: [nbd nbds_max=1024, nfs]
 ```
 

--- a/content/docs/installation/boot-process/image-preloading.md
+++ b/content/docs/installation/boot-process/image-preloading.md
@@ -22,7 +22,7 @@ _Available as of RancherOS v1.4_
 cloud-config file, e.g.:
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   preload_wait: true
 ```
 

--- a/content/docs/installation/cloud/amazon-ecs.md
+++ b/content/docs/installation/cloud/amazon-ecs.md
@@ -23,7 +23,7 @@ For the **User Data**, you'll need to pass in the [cloud-config](/docs/configura
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   environment:
     ECS_CLUSTER: your-ecs-cluster-name
     # Note: You will need to add this variable, if using awslogs for ECS task.
@@ -43,7 +43,7 @@ To select the version, you can update your [cloud-config](/docs/configuration/ba
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   environment:
     ECS_CLUSTER: your-ecs-cluster-name
     # Note: You will need to make sure to include the colon in front of the version.

--- a/content/docs/installation/custom-builds/custom-console.md
+++ b/content/docs/installation/custom-builds/custom-console.md
@@ -16,7 +16,7 @@ Here is an example cloud-config file that can be used to enable the debian conso
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   console: debian
 ```
 

--- a/content/docs/installation/server/pxe.md
+++ b/content/docs/installation/server/pxe.md
@@ -42,7 +42,7 @@ test:
   image: alpine
   command: echo "tell me a secret ${EXTRA_CMDLINE}"
   labels:
-    io.burmilla.os.scope: system
+    io.rancher.os.scope: system
   environment:
   - EXTRA_CMDLINE
 ```

--- a/content/docs/installation/server/raspberry-pi.md
+++ b/content/docs/installation/server/raspberry-pi.md
@@ -48,7 +48,7 @@ You can also use cloud-config to enable Wi-Fi:
 
 ```
 #cloud-config
-burmilla:
+rancher:
   network:
     interfaces:
       wlan0:

--- a/content/docs/installation/upgrading.md
+++ b/content/docs/installation/upgrading.md
@@ -125,7 +125,7 @@ In the `upgrade` key, the `url` is used to find the list of available and curren
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   upgrade:
     url: https://raw.githubusercontent.com/burmilla/releases/master/releases.yml
     image: burmilla/os

--- a/content/docs/networking/_index.md
+++ b/content/docs/networking/_index.md
@@ -17,7 +17,7 @@ If you wanted to configure the interfaces through the cloud config file, you'll 
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   network:
     interfaces:
       eth1:
@@ -43,7 +43,7 @@ Alternatively, you can place the MAC address selection in your cloud config file
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   network:
     interfaces:
       "mac=ea:34:71:66:90:12:01":
@@ -56,7 +56,7 @@ You can aggregate several network links into one virtual link for redundancy and
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   network:
     interfaces:
       bond0:
@@ -89,7 +89,7 @@ In this example, you can create an interface `eth0.100` which is tied to VLAN 10
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   network:
     interfaces:
       eth0:
@@ -102,7 +102,7 @@ In this example, you can create a bridge interface.
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   network:
     interfaces:
       br0:
@@ -132,7 +132,7 @@ write_files:
       set -ex
       echo $@ >> /var/log/net.log
       # the last line of the file needs to be a blank line or a comment
-burmilla:
+rancher:
   network:
     dns:
       nameservers:
@@ -178,7 +178,7 @@ In order to enable WiFi access, update the `cloud-config` with the WiFi network 
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   network:
     interfaces:
       wlan0:
@@ -194,7 +194,7 @@ burmilla:
 
 This Adapter uses a specified network to connect to and sets the IP statically:
 ```yaml
-burmilla:
+rancher:
   network:
     dns:
       nameservers:
@@ -216,7 +216,7 @@ burmilla:
 
 This configuration connects to multiple wireless networks and uses DHCP on each of them:
 ```yaml
-burmilla:
+rancher:
   network:
     interfaces:
       wlan0:
@@ -253,7 +253,7 @@ In order to use BurmillaOS, you will need to use the ISO built for 4G-LTE suppor
 After booting the ISO, there will be a 4G NIC, such as `wwan0`. Use the following `cloud-config` to set the APN parameter.
 
 ```yaml
-burmilla:
+rancher:
   network:
     modem_networks:
       wwan0:

--- a/content/docs/networking/dns.md
+++ b/content/docs/networking/dns.md
@@ -10,7 +10,7 @@ If you wanted to configure the DNS through the cloud config file, you'll need to
 #cloud-config
 
 #Remember, any changes for burmilla will be within the burmilla key
-burmilla:
+rancher:
   network:
     dns:
       search:

--- a/content/docs/networking/proxy-settings.md
+++ b/content/docs/networking/proxy-settings.md
@@ -8,7 +8,7 @@ HTTP proxy settings can be set directly under the `network` key. This will autom
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   network:
     http_proxy: https://myproxy.example.com
     https_proxy: https://myproxy.example.com
@@ -23,7 +23,7 @@ To add the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables to 
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   services:
     myservice:
       ...

--- a/content/docs/storage/state-partition.md
+++ b/content/docs/storage/state-partition.md
@@ -7,7 +7,7 @@ BurmillaOS will store its state in a single partition specified by the `dev` fie
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   state:
     fstype: auto
     dev: LABEL=BURMILLA_STATE
@@ -27,7 +27,7 @@ BurmillaOS will autoformat the partition to `ext4` (_not_ what is set in `fstype
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   state:
     autoformat:
     - /dev/sda

--- a/content/docs/system-services/custom-system-services.md
+++ b/content/docs/system-services/custom-system-services.md
@@ -9,7 +9,7 @@ If you want to boot BurmillaOS with a system service running, you can add the se
 
 ```yaml
 #cloud-config
-burmilla:
+rancher:
   services:
     nginxapp:
       image: nginx
@@ -65,7 +65,7 @@ my-service:
   image: namespace/my-service:v1.0.0
   command: my-command
   labels:
-    io.burmilla.os.scope: "system"
+    io.rancher.os.scope: "system"
     cron.schedule: "0 * * * * ?"
 ```
 
@@ -84,7 +84,7 @@ my-service:
   image: namespace/my-service:v1.0.0
   command: my-command
   labels:
-    io.burmilla.os.scope: "system"
+    io.rancher.os.scope: "system"
   volumes_from:
     - system-volumes
 ```
@@ -180,18 +180,18 @@ We use labels to determine how to handle the service containers.
 
 Key | Value |Description
 ----|-----|---
-`io.burmilla.os.detach` | Default: `true` | Equivalent of `docker run -d`. If set to `false`, equivalent of `docker run --detach=false`
-`io.burmilla.os.scope` | `system` | Use this label to have the container deployed in System Docker instead of Docker.
-`io.burmilla.os.before`/`io.burmilla.os.after` | Service Names (Comma separated list is accepted) | Used to determine order of when containers should be started.
-`io.burmilla.os.createonly` | Default: `false` | When set to `true`, only a `docker create` will be performed and not a `docker start`.
-`io.burmilla.os.reloadconfig` | Default: `false`| When set to `true`, it reloads the configuration.
+`io.rancher.os.detach` | Default: `true` | Equivalent of `docker run -d`. If set to `false`, equivalent of `docker run --detach=false`
+`io.rancher.os.scope` | `system` | Use this label to have the container deployed in System Docker instead of Docker.
+`io.rancher.os.before`/`io.rancher.os.after` | Service Names (Comma separated list is accepted) | Used to determine order of when containers should be started.
+`io.rancher.os.createonly` | Default: `false` | When set to `true`, only a `docker create` will be performed and not a `docker start`.
+`io.rancher.os.reloadconfig` | Default: `false`| When set to `true`, it reloads the configuration.
 
 
 BurmillaOS uses labels to determine if the container should be deployed in System Docker. By default without the label, the container will be deployed in User Docker.
 
 ```yaml
 labels:
-  - io.burmilla.os.scope=system
+  - io.rancher.os.scope=system
 ```
 
 
@@ -201,7 +201,7 @@ labels:
 foo:
   labels:
     # Start foo before bar is launched
-    io.burmilla.os.before: bar
+    io.rancher.os.before: bar
     # Start foo after baz has been launched
-    io.burmilla.os.after: baz
+    io.rancher.os.after: baz
 ```

--- a/content/docs/system-services/environment.md
+++ b/content/docs/system-services/environment.md
@@ -8,7 +8,7 @@ The [environment key](https://docs.docker.com/compose/compose-file/#environment)
 In the example below, `ETCD_DISCOVERY` will be set to `https://discovery.etcd.io/d1cd18f5ee1c1e2223aed6a1734719f7` for the `etcd` service.
 
 ```yaml
-burmilla:
+rancher:
   environment:
     ETCD_DISCOVERY: https://discovery.etcd.io/d1cd18f5ee1c1e2223aed6a1734719f7
   services:
@@ -21,7 +21,7 @@ burmilla:
 Wildcard globbing is also supported. In the example below, `ETCD_DISCOVERY` will be set as in the previous example, along with any other environment variables beginning with `ETCD_`.
 
 ```yaml
-burmilla:
+rancher:
   environment:
     ETCD_DISCOVERY: https://discovery.etcd.io/d1cd18f5ee1c1e2223aed6a1734719f7
   services:
@@ -34,7 +34,7 @@ burmilla:
 There is also a way to extend PATH environment variable, `PATH` or `path` can be set, and multiple values can be comma-separated. Note that need to reboot before taking effect.
 
 ```yaml
-burmilla:
+rancher:
   environment:
     path: /opt/bin,/home/burmilla/bin
 ```


### PR DESCRIPTION
Correct copy/paste failures, configuration still uses rancher instead of burmilla because of backward compatibility