### PR TITLE
Correct upgrade guide from RancherOS

### DIFF
--- a/content/docs/installation/upgrading.md
+++ b/content/docs/installation/upgrading.md
@@ -17,10 +17,10 @@ Before upgrading to any version, please review the release notes on our [release
 Permanently upgrade your existing RancherOS installation to BurmillaOS and begin tracking BurmillaOS releases:
 
 ```bash
-$ sudo ros console switch default
 $ sudo ros config set rancher.upgrade.url \
 https://raw.githubusercontent.com/burmilla/releases/v1.9.x/releases.yml
 $ sudo ros os upgrade
+$ sudo ros console switch default
 ```
 
 ## Version Control


### PR DESCRIPTION
Like I commented to https://github.com/burmilla/os/issues/32#issuecomment-746473985 it looks to be that user need switch console *after* update to BurmillaOS. Other way user end up to hybrid solution where all other parts are from BurmillaOS but console still from RancherOS.

Updated it already to release notes https://github.com/burmilla/os/releases/tag/v1.9.0