### PR TITLE
deploy only on master branch

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,6 +1,9 @@
 name: website
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   publish:


### PR DESCRIPTION
Currently the web is published in any pull to any branch which is wrong, with the change it will only be published when the pull is done in the master branch.