### PR TITLE
refactor docs/releases

### DIFF
--- a/content/docs/releases.md
+++ b/content/docs/releases.md
@@ -5,9 +5,16 @@ weight: 12
 
 # Releases
 
-| Version | Channel | Date |
-|:-------:|:-------:|:----:|
-|[1.9.1](https://github.com/burmilla/os/releases/tag/v1.9.1) | Stable | 02.02.2021|
-|[2.0.0-beta3](https://github.com/burmilla/os/releases/tag/v2.0.0-beta2)| Testing | 24.01.2021|
-|[1.9.0](https://github.com/burmilla/os/releases/tag/v1.9.0) | Stable | 14.12.2020|
-|[2.0.0-beta2](https://github.com/burmilla/os/releases/tag/v2.0.0-beta2)| Testing | 19.11.2020|
+The following is a list of the versions of the operating system in their different branches:
+
+#### Stable
+
+- [v1.9.1](https://github.com/burmilla/os/releases/tag/v1.9.1) | 02.02.2021
+- [v1.9.0](https://github.com/burmilla/os/releases/tag/v1.9.0) | 14.12.2020
+
+#### Testing
+
+- [v2.0.0-beta3](https://github.com/burmilla/os/releases/tag/v2.0.0-beta3) | 24.01.2021
+- [v1.9.1-rc1](https://github.com/burmilla/os/releases/tag/v1.9.1-rc1) | 07.01.2021
+- [v1.9.0-rc1](https://github.com/burmilla/os/releases/tag/v1.9.0-rc1) | 23.11.2020
+- [v2.0.0-beta2](https://github.com/burmilla/os/releases/tag/v2.0.0-beta2) | 19.11.2020

--- a/content/docs/releases.md
+++ b/content/docs/releases.md
@@ -15,6 +15,9 @@ The following is a list of the versions of the operating system in their differe
 #### Testing
 
 - [v2.0.0-beta3](https://github.com/burmilla/os/releases/tag/v2.0.0-beta3) | 24.01.2021
+
+#### Archived
+
 - [v1.9.1-rc1](https://github.com/burmilla/os/releases/tag/v1.9.1-rc1) | 07.01.2021
 - [v1.9.0-rc1](https://github.com/burmilla/os/releases/tag/v1.9.0-rc1) | 23.11.2020
 - [v2.0.0-beta2](https://github.com/burmilla/os/releases/tag/v2.0.0-beta2) | 19.11.2020


### PR DESCRIPTION
I think it would be better to remove the table and put items of the versions we are releasing with their respective release dates.

![image](https://user-images.githubusercontent.com/41587659/106851086-6de74c80-6694-11eb-9e44-adc84b586fd9.png)
