### PR TITLE
Extend Apple silicon virtualization help

### DIFF
--- a/content/docs/installation/workstation/apple-silicon.md
+++ b/content/docs/installation/workstation/apple-silicon.md
@@ -4,4 +4,6 @@ bookToc: false
 # Apple Silicon
 
 On MacOS, particularly on Apple Silicon (M1, M2, M3, ...), BurmillaOS can be tested using [UTM](https://github.com/utmapp/UTM).
-Make sure to disable `UEFI Boot` and use the `virtio-vga` display card emulation.
+To run BurmillaOS on UTM, create a new virtual machine using "Emulate" CPU,
+for a "Linux" operating system, and set the CPU architecture to "x86_64".
+Make sure to disable `UEFI Boot` and use the `virtio-vga` display card emulation in the settings.


### PR DESCRIPTION
This adds a note on how exactly a new VM should be set up with UTM.