### PR TITLE
Remove Openstack installation instructions

### DIFF
--- a/content/docs/installation/_index.md
+++ b/content/docs/installation/_index.md
@@ -24,7 +24,6 @@ Refer to the below resources for more information on installing BurmillaOS on yo
 - [Google Compute Engine](/docs/installation/cloud/gce)
 - [DigitalOcean](/docs/installation/cloud/digital-ocean)
 - [Azure](/docs/installation/cloud/azure)
-- [OpenStack](/docs/installation/cloud/openstack)
 - [VMware ESXi](/docs/installation/cloud/vmware-esxi)
 - [Aliyun](/docs/installation/cloud/aliyun)
 

--- a/content/docs/installation/cloud/_index.md
+++ b/content/docs/installation/cloud/_index.md
@@ -6,6 +6,5 @@ bookCollapseSection: true
 - [Google Compute Engine](/docs/installation/cloud/gce)
 - [DigitalOcean](/docs/installation/cloud/digital-ocean)
 - [Azure](/docs/installation/cloud/azure)
-- [OpenStack](/docs/installation/cloud/openstack)
 - [VMware ESXi](/docs/installation/cloud/vmware-esxi)
 - [Aliyun](/docs/installation/cloud/aliyun)

--- a/content/docs/installation/cloud/openstack.md
+++ b/content/docs/installation/cloud/openstack.md
@@ -1,9 +1,0 @@
----
-title: OpenStack
-bookToc: false
----
-# OpenStack
-
-BurmillaOS releases include an Openstack image that can be found on our [releases page](https://github.com/burmilla/os/releases). The image format is [QCOW3](https://wiki.qemu.org/Features/Qcow3#Fully_QCOW2_backwards-compatible_feature_set) that is backward compatible with QCOW2.
-
-When launching an instance using the image, you must enable **Advanced Options** -> **Configuration Drive** and in order to use a [cloud-config](/docs/configuration/base/#cloud-config) file.


### PR DESCRIPTION
Given the the response https://github.com/burmilla/os/issues/74#issuecomment-812043208 and the absence of special Openstack images in the 2.0.0-rc1 release, I guess the Openstack specific installation instructions can be removed.