### PR TITLE
Replace incorrect "burmilla"s back to "rancher"s

### DIFF
--- a/content/docs/additional-resources/_index.md
+++ b/content/docs/additional-resources/_index.md
@@ -42,7 +42,7 @@ On OS X, `brew` is recommended to install those. On Linux, use your distro packa
 
 To launch BurmillaOS in QEMU from your dev version, you can either use `make run`, or customise the vm using `./scripts/run` and its options. You can use `--append your.kernel=params here` and `--cloud-config your-cloud-config.yml` to configure the BurmillaOS instance you're launching.
 
-You can SSH in using `./scripts/ssh`.  Your SSH keys should have been populated (if you didn't provide your own cloud-config) so you won't need a password.  If you don't have SSH keys, or something is wrong with your cloud-config, then the password is "`burmilla`".
+You can SSH in using `./scripts/ssh`.  Your SSH keys should have been populated (if you didn't provide your own cloud-config) so you won't need a password.  If you don't have SSH keys, or something is wrong with your cloud-config, then the password is "`rancher`".
 
 If you're on OS X, you can run BurmillaOS using [_xhyve_](https://github.com/mist64/xhyve) instead of QEMU: just pass `--xhyve` to `./scripts/run` and `./scripts/ssh`.
 

--- a/content/docs/configuration/advanced/airgap-configuration.md
+++ b/content/docs/configuration/advanced/airgap-configuration.md
@@ -11,7 +11,7 @@ You should use a private Docker registry so that `user-docker` and `system-docke
 2. Set the private registry certificates for `user-docker`. For details, refer to [Certificates for Private Registries](/docs/configuration/docker/private-registries#certificates-for-private-registries)
 3. Set the private registry certificates for `system-docker`. There are two ways to set the certificates:
   - To set the private registry certificates before BurmillaOS starts, you can run a script included with BurmillaOS. For details, refer to [Set Custom Certs in ISO](/docs/configuration/advanced/airgap-configuration#set-custom-certs-in-iso).
-  - To set the private registry certificates after BurmillaOS starts, append your private registry certs to the `/etc/ssl/certs/ca-certificates.crt.burmilla` file. Then reboot to make the certs fully take effect.
+  - To set the private registry certificates after BurmillaOS starts, append your private registry certs to the `/etc/ssl/certs/ca-certificates.crt.rancher` file. Then reboot to make the certs fully take effect.
 4. The images used by BurmillaOS should be pushed to your private registry.
 
 ## Set Custom Certs in ISO

--- a/content/docs/configuration/advanced/resizing-device-partition.md
+++ b/content/docs/configuration/advanced/resizing-device-partition.md
@@ -7,7 +7,7 @@ bookToc: false
 
 The `resize_device` cloud config option can be used to automatically extend the first partition (assuming its `ext4`) to fill the size of it's device.
 
-Once the partition has been resized to fill the device, a `/var/lib/burmilla/resizefs.done` file will be written to prevent the resize tools from being run again. If you need it to run again, delete that file and reboot.
+Once the partition has been resized to fill the device, a `/var/lib/rancher/resizefs.done` file will be written to prevent the resize tools from being run again. If you need it to run again, delete that file and reboot.
 
 ```yaml
 #cloud-config

--- a/content/docs/configuration/advanced/running-commands.md
+++ b/content/docs/configuration/advanced/running-commands.md
@@ -10,8 +10,8 @@ You can automate running commands on boot using the `runcmd` cloud-config direct
 ```yaml
 #cloud-config
 runcmd:
-- [ touch, /home/burmilla/test1 ]
-- echo "test" > /home/burmilla/test2
+- [ touch, /home/rancher/test1 ]
+- echo "test" > /home/rancher/test2
 ```
 
 Commands specified using `runcmd` will be executed within the context of the `console` container.

--- a/content/docs/configuration/base/_index.md
+++ b/content/docs/configuration/base/_index.md
@@ -39,7 +39,7 @@ For more complicated settings, like the [sysctl settings](/docs/configuration/ad
 
 ### Getting Values
 
-You can easily get any value that's been set in the `/var/lib/burmilla/conf/cloud-config.yml` file. Let's see how easy it is to get the DNS configuration of the system.
+You can easily get any value that's been set in the `/var/lib/rancher/conf/cloud-config.yml` file. Let's see how easy it is to get the DNS configuration of the system.
 
 ```shell
 $ sudo ros config get rancher.network.dns.nameservers
@@ -49,15 +49,15 @@ $ sudo ros config get rancher.network.dns.nameservers
 
 ### Setting Values
 
-You can set values in the `/var/lib/burmilla/conf/cloud-config.yml` file.
+You can set values in the `/var/lib/rancher/conf/cloud-config.yml` file.
 
-Setting a simple value in the `/var/lib/burmilla/conf/cloud-config.yml`
+Setting a simple value in the `/var/lib/rancher/conf/cloud-config.yml`
 
 ```shell
 $ sudo ros config set rancher.docker.tls true
 ```
 
-Setting a list in the `/var/lib/burmilla/conf/cloud-config.yml`
+Setting a list in the `/var/lib/rancher/conf/cloud-config.yml`
 
 ```shell
 $ sudo ros config set rancher.network.dns.nameservers "['8.8.8.8','8.8.4.4']"

--- a/content/docs/configuration/base/ssh-keys.md
+++ b/content/docs/configuration/base/ssh-keys.md
@@ -17,7 +17,7 @@ ssh_authorized_keys:
 When we pass the cloud-config file during the `ros install` command, it will allow these ssh keys to be associated with the **burmilla** user. You can ssh into BurmillaOS using the key.
 
 ```shell
-$ ssh -i /path/to/private/key burmilla@<ip-address>
+$ ssh -i /path/to/private/key rancher@<ip-address>
 ```
 
 Please note that OpenSSH 7.0 and greater similarly disable the ssh-dss (DSA) public key algorithm. It too is weak and we recommend against its use.

--- a/content/docs/configuration/base/ssh-keys.md
+++ b/content/docs/configuration/base/ssh-keys.md
@@ -14,7 +14,7 @@ ssh_authorized_keys:
   - ssh-rsa BBB...ZZZ example2@burmilla
 ```
 
-When we pass the cloud-config file during the `ros install` command, it will allow these ssh keys to be associated with the **burmilla** user. You can ssh into BurmillaOS using the key.
+When we pass the cloud-config file during the `ros install` command, it will allow these ssh keys to be associated with the **rancher** user. You can ssh into BurmillaOS using the key.
 
 ```shell
 $ ssh -i /path/to/private/key rancher@<ip-address>

--- a/content/docs/configuration/base/switching-consoles.md
+++ b/content/docs/configuration/base/switching-consoles.md
@@ -42,7 +42,7 @@ The default console is persistent. Persistent console means that the console con
 /home
 /opt
 /var/lib/docker
-/var/lib/burmilla
+/var/lib/rancher
 ```
 
 <br>

--- a/content/docs/configuration/docker/_index.md
+++ b/content/docs/configuration/docker/_index.md
@@ -238,7 +238,7 @@ OPTIONS:
 When using `--authorized-keys`, you will need to put the key file in one of the following directories:
 
 ```
-/var/lib/burmilla/
+/var/lib/rancher/
 /opt/
 /home/
 ```

--- a/content/docs/configuration/docker/private-registries.md
+++ b/content/docs/configuration/docker/private-registries.md
@@ -46,7 +46,7 @@ Configuring authentication for the Docker client is not handled by the `registry
 ```yaml
 #cloud-config
 write_files:
-  - path: /home/burmilla/.docker/config.json
+  - path: /home/rancher/.docker/config.json
     permissions: "0755"
     owner: burmilla
     content: |

--- a/content/docs/configuration/docker/setting-up-docker-tls.md
+++ b/content/docs/configuration/docker/setting-up-docker-tls.md
@@ -31,7 +31,7 @@ You also need client cert and key to access Docker via a TCP socket now:
 
 ```
 $ sudo ros tls gen
-  INFO[0000] Out directory (-d, --dir) not specified, using default: /home/burmilla/.docker
+  INFO[0000] Out directory (-d, --dir) not specified, using default: /home/rancher/.docker
 ```
 
 All the docker client TLS files are in `~/.docker` dir now.
@@ -46,7 +46,7 @@ $ docker --tlsverify version
 
 Because all the necessary files are in the `~/.docker` dir, you don't need to specify them using `--tlscacert` `--tlscert` and `--tlskey` options. You also don't need `-H` to access Docker on localhost.
 
-Copy the files from `/home/burmilla/.docker` to `$HOME/.docker` on your client machine if you need to access Docker on your BurmillaOS host from there.
+Copy the files from `/home/rancher/.docker` to `$HOME/.docker` on your client machine if you need to access Docker on your BurmillaOS host from there.
 
 On your client machine, set the Docker host and test out if Docker commands work.
 

--- a/content/docs/installation/boot-process/_index.md
+++ b/content/docs/installation/boot-process/_index.md
@@ -33,7 +33,7 @@ This service provides the BurmillaOS user interface by running `sshd` and `getty
    * Mount devices specified in the `mounts` in the [cloud-config](/docs/storage/additional-mounts).
    * Set sysctl parameters specified in  the`rancher.sysctl` [cloud-config](/docs/configuration/advanced/sysctl).
 4. If user-data contained a file that started with `#!`, then a file would be saved at `/var/lib/rancher/conf/cloud-config-script` during cloud-init and then executed. Any errors are ignored.
-5. Runs `/opt/burmilla/bin/start.sh` if it exists and is executable. Any errors are ignored.
+5. Runs `/opt/rancher/bin/start.sh` if it exists and is executable. Any errors are ignored.
 6. Runs `/etc/rc.local` if it exists and is executable. Any errors are ignored.
 
 ## Docker

--- a/content/docs/installation/boot-process/_index.md
+++ b/content/docs/installation/boot-process/_index.md
@@ -32,7 +32,7 @@ This service provides the BurmillaOS user interface by running `sshd` and `getty
    * Resizes the device specified by setting `rancher.resize_device` in the [cloud-config](/docs/configuration/advanced/resizing-device-partition).
    * Mount devices specified in the `mounts` in the [cloud-config](/docs/storage/additional-mounts).
    * Set sysctl parameters specified in  the`rancher.sysctl` [cloud-config](/docs/configuration/advanced/sysctl).
-4. If user-data contained a file that started with `#!`, then a file would be saved at `/var/lib/burmilla/conf/cloud-config-script` during cloud-init and then executed. Any errors are ignored.
+4. If user-data contained a file that started with `#!`, then a file would be saved at `/var/lib/rancher/conf/cloud-config-script` during cloud-init and then executed. Any errors are ignored.
 5. Runs `/opt/burmilla/bin/start.sh` if it exists and is executable. Any errors are ignored.
 6. Runs `/etc/rc.local` if it exists and is executable. Any errors are ignored.
 

--- a/content/docs/installation/boot-process/_index.md
+++ b/content/docs/installation/boot-process/_index.md
@@ -27,7 +27,7 @@ This service provides the BurmillaOS user interface by running `sshd` and `getty
 1. If the `rancher.password=<password>` kernel parameter exists, it sets `<password>` as the password for the `rancher` user.
 2. If there are no host SSH keys, it generates host SSH keys and saves them under `rancher.ssh.keys` in [cloud-config](/docs/configuration/base/#cloud-config).
 3. Runs `cloud-init -execute`, which does the following:
-   * Updates `.ssh/authorized_keys` in `/home/burmilla` and `/home/docker` in the [cloud-config](/docs/configuration/base/ssh-keys) and metadata.
+   * Updates `.ssh/authorized_keys` in `/home/rancher` and `/home/docker` in the [cloud-config](/docs/configuration/base/ssh-keys) and metadata.
    * Writes files specified by setting `write_files` in the [cloud-config](/docs/configuration/advanced/write-files).
    * Resizes the device specified by setting `rancher.resize_device` in the [cloud-config](/docs/configuration/advanced/resizing-device-partition).
    * Mount devices specified in the `mounts` in the [cloud-config](/docs/storage/additional-mounts).

--- a/content/docs/installation/boot-process/_index.md
+++ b/content/docs/installation/boot-process/_index.md
@@ -24,7 +24,7 @@ Runs `ntpd` in a System Docker container.
 
 This service provides the BurmillaOS user interface by running `sshd` and `getty`. It completes the BurmillaOS configuration on start up:
 
-1. If the `rancher.password=<password>` kernel parameter exists, it sets `<password>` as the password for the `burmilla` user.
+1. If the `rancher.password=<password>` kernel parameter exists, it sets `<password>` as the password for the `rancher` user.
 2. If there are no host SSH keys, it generates host SSH keys and saves them under `rancher.ssh.keys` in [cloud-config](/docs/configuration/base/#cloud-config).
 3. Runs `cloud-init -execute`, which does the following:
    * Updates `.ssh/authorized_keys` in `/home/burmilla` and `/home/docker` in the [cloud-config](/docs/configuration/base/ssh-keys) and metadata.

--- a/content/docs/installation/boot-process/cloud-init.md
+++ b/content/docs/installation/boot-process/cloud-init.md
@@ -21,5 +21,5 @@ Although the specifics vary based on provider, a metadata file will typically co
 2. `/usr/share/ros/oem/oem-config.yml` - This will typically exist by OEM, which should **not** be modified by users.
 3. Files in `/var/lib/burmilla/conf/cloud-config.d/` ordered by filename. If a file is passed in through user-data, it is written by cloud-init and saved as `/var/lib/burmilla/conf/cloud-config.d/boot.yml`.
 4. `/var/lib/burmilla/conf/cloud-config.yml` - If you set anything with `ros config set`, the changes are saved in this file.
-5. Kernel parameters with names starting with `burmilla`.
+5. Kernel parameters with names starting with `rancher`.
 6. `/var/lib/burmilla/conf/metadata` - Metadata added by cloud-init.

--- a/content/docs/installation/boot-process/cloud-init.md
+++ b/content/docs/installation/boot-process/cloud-init.md
@@ -7,11 +7,11 @@ Userdata and metadata can be fetched from a cloud provider, VM runtime, or manag
 
 ## Userdata
 
-Userdata is a file given by users when launching BurmillaOS hosts. It is stored in different locations depending on its format. If the userdata is a [cloud-config](/docs/configuration/base/#cloud-config) file, indicated by beginning with `#cloud-config` and being in YAML format, it is stored in `/var/lib/burmilla/conf/cloud-config.d/boot.yml`. If the userdata is a script, indicated by beginning with `#!`, it is stored in `/var/lib/burmilla/conf/cloud-config-script`.
+Userdata is a file given by users when launching BurmillaOS hosts. It is stored in different locations depending on its format. If the userdata is a [cloud-config](/docs/configuration/base/#cloud-config) file, indicated by beginning with `#cloud-config` and being in YAML format, it is stored in `/var/lib/rancher/conf/cloud-config.d/boot.yml`. If the userdata is a script, indicated by beginning with `#!`, it is stored in `/var/lib/rancher/conf/cloud-config-script`.
 
 ## Metadata
 
-Although the specifics vary based on provider, a metadata file will typically contain information about the BurmillaOS host and contain additional configuration. Its primary purpose within BurmillaOS is to provide an alternate source for SSH keys and hostname configuration. For example, AWS launches hosts with a set of authorized keys and BurmillaOS obtains these via metadata. Metadata is stored in `/var/lib/burmilla/conf/metadata`.
+Although the specifics vary based on provider, a metadata file will typically contain information about the BurmillaOS host and contain additional configuration. Its primary purpose within BurmillaOS is to provide an alternate source for SSH keys and hostname configuration. For example, AWS launches hosts with a set of authorized keys and BurmillaOS obtains these via metadata. Metadata is stored in `/var/lib/rancher/conf/metadata`.
 
 ## Configuration Load Order
 
@@ -19,7 +19,7 @@ Although the specifics vary based on provider, a metadata file will typically co
 
 1. `/usr/share/ros/os-config.yml` - This is the system default configuration, which should **not** be modified by users.
 2. `/usr/share/ros/oem/oem-config.yml` - This will typically exist by OEM, which should **not** be modified by users.
-3. Files in `/var/lib/burmilla/conf/cloud-config.d/` ordered by filename. If a file is passed in through user-data, it is written by cloud-init and saved as `/var/lib/burmilla/conf/cloud-config.d/boot.yml`.
-4. `/var/lib/burmilla/conf/cloud-config.yml` - If you set anything with `ros config set`, the changes are saved in this file.
+3. Files in `/var/lib/rancher/conf/cloud-config.d/` ordered by filename. If a file is passed in through user-data, it is written by cloud-init and saved as `/var/lib/rancher/conf/cloud-config.d/boot.yml`.
+4. `/var/lib/rancher/conf/cloud-config.yml` - If you set anything with `ros config set`, the changes are saved in this file.
 5. Kernel parameters with names starting with `rancher`.
-6. `/var/lib/burmilla/conf/metadata` - Metadata added by cloud-init.
+6. `/var/lib/rancher/conf/metadata` - Metadata added by cloud-init.

--- a/content/docs/installation/boot-process/image-preloading.md
+++ b/content/docs/installation/boot-process/image-preloading.md
@@ -3,7 +3,7 @@ bookToc: false
 ---
 # Image Preloading
 
-On boot, BurmillaOS scans `/var/lib/burmilla/preload/docker` and `/var/lib/burmilla/preload/system-docker` directories and tries to load container image archives it finds there, with `docker load` and `system-docker load`.
+On boot, BurmillaOS scans `/var/lib/rancher/preload/docker` and `/var/lib/rancher/preload/system-docker` directories and tries to load container image archives it finds there, with `docker load` and `system-docker load`.
 
 The archives are `.tar` files, optionally compressed with `xz` or `gzip`. These can be produced by `docker save` command, e.g.:
 
@@ -11,7 +11,7 @@ The archives are `.tar` files, optionally compressed with `xz` or `gzip`. These 
 $ docker save my-image1 my-image2 some-other/image3 | xz > my-images.tar.xz
 ```
 
-The resulting files should be placed into `/var/lib/burmilla/preload/docker` or `/var/lib/burmilla/preload/system-docker` (depending on whether you want it preloaded into Docker or System Docker).
+The resulting files should be placed into `/var/lib/rancher/preload/docker` or `/var/lib/rancher/preload/system-docker` (depending on whether you want it preloaded into Docker or System Docker).
 
 Pre-loading process only reads each new archive once, so it won't take time on subsequent boots (`<archive>.done` files are created to mark the read archives). If you update the archive (place a newer archive with the same name) it'll get read on the next boot as well.
 

--- a/content/docs/installation/boot-process/logging.md
+++ b/content/docs/installation/boot-process/logging.md
@@ -38,7 +38,7 @@ For example, on my current test system, I have set the kernel boot line to:
 
 
 ```shell
-printk.devkmsg=on console=tty1 rancher.autologin=tty1 console=ttyS0 rancher.autologin=ttyS0 rancher.state.dev=LABEL=BURMILLA_STATE rancher.state.autoformat=[/dev/sda,/dev/vda] rancher.rm_usr loglevel=8 netconsole=+9999@10.0.2.14/,514@192.168.42.223/
+printk.devkmsg=on console=tty1 rancher.autologin=tty1 console=ttyS0 rancher.autologin=ttyS0 rancher.state.dev=LABEL=RANCHER_STATE rancher.state.autoformat=[/dev/sda,/dev/vda] rancher.rm_usr loglevel=8 netconsole=+9999@10.0.2.14/,514@192.168.42.223/
 ```
 
 The kernel boot parameters can be set during installation using `sudo ros install --append "...."`, or on an installed BurmillaOS system,  by running `sudo ros config syslinux` (which will start vi in a container, editing the `global.cfg` boot config file.

--- a/content/docs/installation/cloud/aliyun.md
+++ b/content/docs/installation/cloud/aliyun.md
@@ -32,4 +32,4 @@ Since the image is private, we need to use the `Custom Images`.
 
 ![BurmillaOS on Aliyun 2](/images/BurmillaOS_aliyun2.jpg)
 
-After the instance is successfully started, we can login with the `burmilla` user via SSH.
+After the instance is successfully started, we can login with the `rancher` user via SSH.

--- a/content/docs/installation/cloud/aws-ec2.md
+++ b/content/docs/installation/cloud/aws-ec2.md
@@ -45,13 +45,13 @@ From a command line, log into the EC2 Instance. If you added ssh keys using a cl
 both those keys, and the one you selected in the AWS UI will be installed.
 
 ```
-$ ssh -i /Directory/of/MySSHKeyName.pem burmilla@<ip-of-ec2-instance>
+$ ssh -i /Directory/of/MySSHKeyName.pem rancher@<ip-of-ec2-instance>
 ```
 
 If you have issues logging into BurmillaOS, try using this command to help debug the issue.
 
 ```
-$ ssh -v -i /Directory/of/MySSHKeyName.pem burmilla@<ip-of-ec2-instance>
+$ ssh -v -i /Directory/of/MySSHKeyName.pem rancher@<ip-of-ec2-instance>
 ```
 
 ## Latest AMI Releases

--- a/content/docs/installation/cloud/digital-ocean.md
+++ b/content/docs/installation/cloud/digital-ocean.md
@@ -49,5 +49,5 @@ write_files:
         done
       done
 
-      docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -v /opt/burmilla:/var/lib/rancher burmilla/burmilla:${burmilla_version}
+      docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -v /opt/rancher:/var/lib/rancher burmilla/burmilla:${burmilla_version}
 ```

--- a/content/docs/installation/cloud/digital-ocean.md
+++ b/content/docs/installation/cloud/digital-ocean.md
@@ -49,5 +49,5 @@ write_files:
         done
       done
 
-      docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -v /opt/burmilla:/var/lib/burmilla burmilla/burmilla:${burmilla_version}
+      docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -v /opt/burmilla:/var/lib/rancher burmilla/burmilla:${burmilla_version}
 ```

--- a/content/docs/installation/cloud/digital-ocean.md
+++ b/content/docs/installation/cloud/digital-ocean.md
@@ -23,7 +23,7 @@ To start a BurmillaOS Droplet on Digital Ocean:
 1. Click **Create.**
 
 
-You can access the host via SSH after the Droplet is booted. The default user is `burmilla`.
+You can access the host via SSH after the Droplet is booted. The default user is `rancher`.
 
 Below is an example `cloud-config` file that you can use to initialize the Droplet with user data, such as deploying Rancher:
 

--- a/content/docs/installation/cloud/gce.md
+++ b/content/docs/installation/cloud/gce.md
@@ -126,7 +126,7 @@ ssh_authorized_keys:
 Remember, the SSH keys are passed to the **burmilla** user. The SSH keys can be passed from the project level, the instance level or through the cloud config file. If you add any of these SSH keys after the instance has been created, the instance will need to be reset before the SSH keys are passed through.
 
 ```
-$ gcloud compute ssh burmilla@<INSTANCE_NAME> --project <PROJECT_ID> --zone <ZONE_OF_INSTANCE>
+$ gcloud compute ssh rancher@<INSTANCE_NAME> --project <PROJECT_ID> --zone <ZONE_OF_INSTANCE>
 ```
 
 If you have issues logging into BurmillaOS, try using this command to help debug the instance.

--- a/content/docs/installation/cloud/gce.md
+++ b/content/docs/installation/cloud/gce.md
@@ -16,7 +16,7 @@ BurmillaOS is available as an image in GCE, and can be easily run in Google Comp
 
 ## Launching BurmillaOS using `gcloud compute`
 
-After the image is uploaded, we can use the `gcloud compute` [command-line tool](https://cloud.google.com/compute/docs/gcloud-compute/) to start a new instance. It automatically merges the SSH keys from the project and adds the keys to the **burmilla** user. If you don't have any project level SSH keys, go to the _Adding SSH Keys_ section to learn more about adding SSH keys.
+After the image is uploaded, we can use the `gcloud compute` [command-line tool](https://cloud.google.com/compute/docs/gcloud-compute/) to start a new instance. It automatically merges the SSH keys from the project and adds the keys to the **rancher** user. If you don't have any project level SSH keys, go to the _Adding SSH Keys_ section to learn more about adding SSH keys.
 
 Since the image is private, we need to follow Google's [instructions](https://cloud.google.com/compute/docs/creating-custom-image#start_an_instance_from_a_custom_image).
 
@@ -26,7 +26,7 @@ $ gcloud compute instances create --project <PROJECT_ID> --zone <ZONE_TO_CREATE_
 
 ## Using a Cloud Config File with GCE
 
-If you want to pass in your own cloud config file that will be processed by [cloud init](/docs/configuration/#cloud-config), you can pass it as metadata upon creation of the instance during the `gcloud compute` command. The file will need to be stored locally before running the command. The key of the metadata will be `user-data` and the value is the location of the file. If any SSH keys are added in the cloud config file, it will also be added to the **burmilla** user.
+If you want to pass in your own cloud config file that will be processed by [cloud init](/docs/configuration/#cloud-config), you can pass it as metadata upon creation of the instance during the `gcloud compute` command. The file will need to be stored locally before running the command. The key of the metadata will be `user-data` and the value is the location of the file. If any SSH keys are added in the cloud config file, it will also be added to the **rancher** user.
 
 ```bash
 $ gcloud compute instances create --project <PROJECT_ID> --zone <ZONE_TO_CREATE_INSTANCE> <INSTANCE_NAME> --image <PRIVATE_IMAGE_NAME> --metadata-from-file user-data=/Directory/of/Cloud_Config.yml
@@ -93,7 +93,7 @@ In your project, click on **Metadata**, which is located within Compute -> Compu
 
 Add the SSH keys that you want to have access to any instances within your project.
 
-Note: If you do this after any BurmillaOS instance is created, you will need to reset the instance so that the SSH keys are added to the **burmilla** user.
+Note: If you do this after any BurmillaOS instance is created, you will need to reset the instance so that the SSH keys are added to the **rancher** user.
 
 **Option 2: Instance Level SSH Keys**
 
@@ -105,7 +105,7 @@ After the SSH keys have been added, you'll need to reset the machine, by clickin
 
 ![BurmillaOS on GCE 9](https://raw.githubusercontent.com/burmilla/rancher.github.io/master/img/BurmillaOS_gce9.png)
 
-After a little bit, you will be able to SSH into the box using the **burmilla** user.
+After a little bit, you will be able to SSH into the box using the **rancher** user.
 
 **Option 3: Using the Cloud Config file**
 
@@ -123,7 +123,7 @@ ssh_authorized_keys:
 ## Logging into BurmillaOS
 ----
 
-Remember, the SSH keys are passed to the **burmilla** user. The SSH keys can be passed from the project level, the instance level or through the cloud config file. If you add any of these SSH keys after the instance has been created, the instance will need to be reset before the SSH keys are passed through.
+Remember, the SSH keys are passed to the **rancher** user. The SSH keys can be passed from the project level, the instance level or through the cloud config file. If you add any of these SSH keys after the instance has been created, the instance will need to be reset before the SSH keys are passed through.
 
 ```
 $ gcloud compute ssh rancher@<INSTANCE_NAME> --project <PROJECT_ID> --zone <ZONE_OF_INSTANCE>

--- a/content/docs/installation/custom-builds/custom-console.md
+++ b/content/docs/installation/custom-builds/custom-console.md
@@ -115,7 +115,7 @@ All consoles except the default (busybox) console are persistent. Persistent con
 /home
 /opt
 /var/lib/docker
-/var/lib/burmilla
+/var/lib/rancher
 ```
 
 <br>

--- a/content/docs/installation/server/install-to-disk.md
+++ b/content/docs/installation/server/install-to-disk.md
@@ -91,7 +91,7 @@ $ ros install -d <disk> -c <cloud-config.yaml> -s
 
 ## SSH into BurmillaOS
 
-After installing BurmillaOS, you can ssh into BurmillaOS using your private key and the **burmilla** user.
+After installing BurmillaOS, you can ssh into BurmillaOS using your private key and the **rancher** user.
 
 ```bash
 $ ssh -i /path/to/private/key rancher@<ip-address>

--- a/content/docs/installation/server/install-to-disk.md
+++ b/content/docs/installation/server/install-to-disk.md
@@ -10,7 +10,7 @@ The `ros install` command orchestrates the installation from the `burmilla/os` c
 
 The easiest way to log in is to pass a `cloud-config.yml` file containing your public SSH keys. To learn more about what's supported in our cloud-config, please read our [documentation](/docs/configuration/base/#cloud-config).
 
-The `ros install` command will process your `cloud-config.yml` file specified with the `-c` flag. This file will also be placed onto the disk and installed to `/var/lib/burmilla/conf/`. It will be evaluated on every boot.
+The `ros install` command will process your `cloud-config.yml` file specified with the `-c` flag. This file will also be placed onto the disk and installed to `/var/lib/rancher/conf/`. It will be evaluated on every boot.
 
 Create a cloud-config file with a SSH key, this allows you to SSH into the box as the burmilla user. The yml file would look like this:
 

--- a/content/docs/installation/server/install-to-disk.md
+++ b/content/docs/installation/server/install-to-disk.md
@@ -58,7 +58,7 @@ Status: Downloaded newer image for burmilla/os:v2.0.0
 Continue with reboot [y/N]:
 ```
 
-After installing BurmillaOS to disk, you will no longer be automatically logged in as the `burmilla` user. You'll need to have added in SSH keys within your [cloud-config file](/docs/configuration/base/#cloud-config).
+After installing BurmillaOS to disk, you will no longer be automatically logged in as the `rancher` user. You'll need to have added in SSH keys within your [cloud-config file](/docs/configuration/base/#cloud-config).
 
 ### Installing a Different Version
 

--- a/content/docs/installation/server/install-to-disk.md
+++ b/content/docs/installation/server/install-to-disk.md
@@ -12,7 +12,7 @@ The easiest way to log in is to pass a `cloud-config.yml` file containing your p
 
 The `ros install` command will process your `cloud-config.yml` file specified with the `-c` flag. This file will also be placed onto the disk and installed to `/var/lib/rancher/conf/`. It will be evaluated on every boot.
 
-Create a cloud-config file with a SSH key, this allows you to SSH into the box as the burmilla user. The yml file would look like this:
+Create a cloud-config file with a SSH key, this allows you to SSH into the box as the `rancher` user. The yml file would look like this:
 
 ```yaml
 #cloud-config

--- a/content/docs/installation/server/install-to-disk.md
+++ b/content/docs/installation/server/install-to-disk.md
@@ -94,7 +94,7 @@ $ ros install -d <disk> -c <cloud-config.yaml> -s
 After installing BurmillaOS, you can ssh into BurmillaOS using your private key and the **burmilla** user.
 
 ```bash
-$ ssh -i /path/to/private/key burmilla@<ip-address>
+$ ssh -i /path/to/private/key rancher@<ip-address>
 ```
 
 ## Installing with no Internet Access

--- a/content/docs/installation/server/pxe.md
+++ b/content/docs/installation/server/pxe.md
@@ -11,7 +11,7 @@ bookToc: false
 # Location of Kernel/Initrd images
 set base-url <url>
 
-kernel ${base-url}/vmlinuz rancher.state.dev=LABEL=BURMILLA_STATE rancher.state.autoformat=[/dev/sda] rancher.state.wait rancher.cloud_init.datasources=[url:http://example.com/cloud-config]
+kernel ${base-url}/vmlinuz rancher.state.dev=LABEL=RANCHER_STATE rancher.state.autoformat=[/dev/sda] rancher.state.wait rancher.cloud_init.datasources=[url:http://example.com/cloud-config]
 initrd ${base-url}/initrd
 boot
 ```
@@ -30,7 +30,7 @@ will be passed to the BurmillaOS init process and stored in the `root` accessibl
 For example, the `kernel` line above could be written as:
 
 ```bash
-kernel ${base-url}/vmlinuz rancher.state.dev=LABEL=BURMILLA_STATE rancher.state.autoformat=[/dev/sda] -- rancher.cloud_init.datasources=[url:http://example.com/cloud-config]
+kernel ${base-url}/vmlinuz rancher.state.dev=LABEL=RANCHER_STATE rancher.state.autoformat=[/dev/sda] -- rancher.cloud_init.datasources=[url:http://example.com/cloud-config]
 ```
 
 The hidden part of the command line can be accessed with either `sudo ros config get rancher.environment.EXTRA_CMDLINE`, or by using a service file's environment array.

--- a/content/docs/installation/server/pxe.md
+++ b/content/docs/installation/server/pxe.md
@@ -25,7 +25,7 @@ If you don't add `rancher.state.autoformat`, BurmillaOS will run completely in m
 _Available as of RancherOS v0.9_
 
 Secrets can be put on the `kernel` parameters line afer a `--` double dash, and they will be not be shown in any `/proc/cmdline`. These parameters
-will be passed to the BurmillaOS init process and stored in the `root` accessible `/var/lib/burmilla/conf/cloud-init.d/init.yml` file, and are available to the root user from the `ros config` commands.
+will be passed to the BurmillaOS init process and stored in the `root` accessible `/var/lib/rancher/conf/cloud-init.d/init.yml` file, and are available to the root user from the `ros config` commands.
 
 For example, the `kernel` line above could be written as:
 

--- a/content/docs/installation/workstation/boot-from-iso.md
+++ b/content/docs/installation/workstation/boot-from-iso.md
@@ -13,7 +13,7 @@ VMware     | burmillaos-vmware.iso
 Hyper-V    | burmillaos-hyperv.iso
 Proxmox VE | burmillaos-proxmoxve.iso
 
-You must boot with enough memory which you can refer to [here](/#hardware-requirements). If you boot with the ISO, you will automatically be logged in as the `burmilla` user. Only the ISO is set to use autologin by default. If you run from a cloud or install to disk, SSH keys or a password of your choice is expected to be used.
+You must boot with enough memory which you can refer to [here](/#hardware-requirements). If you boot with the ISO, you will automatically be logged in as the `rancher` user. Only the ISO is set to use autologin by default. If you run from a cloud or install to disk, SSH keys or a password of your choice is expected to be used.
 
 ## Install to Disk
 

--- a/content/docs/networking/_index.md
+++ b/content/docs/networking/_index.md
@@ -13,7 +13,7 @@ $ sudo ros config set rancher.network.interfaces.eth1.mtu 1500
 $ sudo ros config set rancher.network.interfaces.eth1.dhcp false
 ```
 
-If you wanted to configure the interfaces through the cloud config file, you'll need to place interface configurations within the `burmilla` key.
+If you wanted to configure the interfaces through the cloud config file, you'll need to place interface configurations within the `rancher` key.
 
 ```yaml
 #cloud-config

--- a/content/docs/networking/dns.md
+++ b/content/docs/networking/dns.md
@@ -9,7 +9,7 @@ If you wanted to configure the DNS through the cloud config file, you'll need to
 ```yaml
 #cloud-config
 
-#Remember, any changes for burmilla will be within the burmilla key
+#Remember, any changes for rancher will be within the rancher key
 rancher:
   network:
     dns:

--- a/content/docs/networking/dns.md
+++ b/content/docs/networking/dns.md
@@ -4,7 +4,7 @@ bookToc: false
 ---
 # Configuring DNS
 
-If you wanted to configure the DNS through the cloud config file, you'll need to place DNS configurations within the `burmilla` key.
+If you wanted to configure the DNS through the cloud config file, you'll need to place DNS configurations within the `rancher` key.
 
 ```yaml
 #cloud-config

--- a/content/docs/quick-start-guide.md
+++ b/content/docs/quick-start-guide.md
@@ -96,12 +96,12 @@ In the command, we used `--net=host` to tell System Docker not to containerize t
 ![System Docker Container](/images/busydash.png)
 
 
-To make the container survive during the reboots, you can create the `/opt/burmilla/bin/start.sh` script, and add the Docker start line to launch the Docker at each startup.
+To make the container survive during the reboots, you can create the `/opt/rancher/bin/start.sh` script, and add the Docker start line to launch the Docker at each startup.
 
 ```bash
-$ sudo mkdir -p /opt/burmilla/bin
-$ echo "sudo system-docker start busydash" | sudo tee -a /opt/burmilla/bin/start.sh
-$ sudo chmod 755 /opt/burmilla/bin/start.sh
+$ sudo mkdir -p /opt/rancher/bin
+$ echo "sudo system-docker start busydash" | sudo tee -a /opt/rancher/bin/start.sh
+$ sudo chmod 755 /opt/rancher/bin/start.sh
 ```
 
 ### Using ROS

--- a/content/docs/storage/custom-partition-layout.md
+++ b/content/docs/storage/custom-partition-layout.md
@@ -5,16 +5,16 @@ weight: 1
 # How to custom partition layout
 
 When users use the default `ros install`, ROS will automatically create one partition on the root disk.
-It will be the only partition with the label BURMILLA_STATE.
+It will be the only partition with the label RANCHER_STATE.
 But sometimes users want to be able to customize the root disk partition to isolate the data.
 
 > The following defaults to MBR mode, GPT mode has not been tested.
 ## Partions
-### BURMILLA_STATE
+### RANCHER_STATE
 
-As mentioned above, the default mode is that ROS will automatically create one partition with the label BURMILLA_STATE.
+As mentioned above, the default mode is that ROS will automatically create one partition with the label RANCHER_STATE.
 
-In addition, we can have other partitions, e.g.: two partitions, one is BURMILLA_STATE and the other is a normal partition.
+In addition, we can have other partitions, e.g.: two partitions, one is RANCHER_STATE and the other is a normal partition.
 
 First boot a ROS instance from ISO, then manually format and partition `/dev/sda` , the reference configuration is as follows:
 
@@ -32,7 +32,7 @@ Device     Boot   Start      End Sectors  Size Id Type
 /dev/sda2       7503872 10503167 2999296  1.4G 83 Linux
 
 [root@burmilla oem]# blkid
-/dev/sda1: LABEL="BURMILLA_STATE" UUID="512f212b-3130-458e-a2d1-1d601c34d4e4" TYPE="ext4" PARTUUID="9fff87e9-01"
+/dev/sda1: LABEL="RANCHER_STATE" UUID="512f212b-3130-458e-a2d1-1d601c34d4e4" TYPE="ext4" PARTUUID="9fff87e9-01"
 /dev/sda2: UUID="3828e3ac-b825-4898-9072-45da9d37c2a6" TYPE="ext4" PARTUUID="9fff87e9-02"
 ```
 
@@ -46,11 +46,11 @@ $ ros config set rancher.docker.graph /mnt/s
 $ reboot
 ```
 
-> In this mode, the BURMILLA_STATE partition capacity cannot exceed 3.8GiB, otherwise the bootloader may not recognize the boot disk. This is the test result on VirtualBox.
+> In this mode, the RANCHER_STATE partition capacity cannot exceed 3.8GiB, otherwise the bootloader may not recognize the boot disk. This is the test result on VirtualBox.
 
 ### BURMILLA_BOOT
 
-When you only use the BURMILLA_STATE partition, the bootloader will be installed in the `/boot` directory.
+When you only use the RANCHER_STATE partition, the bootloader will be installed in the `/boot` directory.
 
 ```shell
 $ system-docker run -it --rm -v /:/host alpine
@@ -75,12 +75,12 @@ Device     Boot   Start      End Sectors  Size Id Type
 /dev/sda3       7503872 10503167 2999296  1.4G 83 Linux
 
 [root@burmilla burmilla]# mkfs.ext4 -L BURMILLA_BOOT /dev/sda1
-[root@burmilla burmilla]# mkfs.ext4 -L BURMILLA_STATE /dev/sda2
+[root@burmilla burmilla]# mkfs.ext4 -L RANCHER_STATE /dev/sda2
 [root@burmilla burmilla]# mkfs.ext4 /dev/sda3
 
 [root@burmilla burmilla]# blkid
 /dev/sda1: LABEL="BURMILLA_BOOT" UUID="43baeac3-11f3-4eed-acfa-64daf66b26c8" TYPE="ext4" PARTUUID="e32b3025-01"
-/dev/sda2: LABEL="BURMILLA_STATE" UUID="16f1ecef-dbe4-42a2-87a1-611939684e0b" TYPE="ext4" PARTUUID="e32b3025-02"
+/dev/sda2: LABEL="RANCHER_STATE" UUID="16f1ecef-dbe4-42a2-87a1-611939684e0b" TYPE="ext4" PARTUUID="e32b3025-02"
 /dev/sda3: UUID="9f34e161-0eee-48f9-93de-3b7c54dea437" TYPE="ext4" PARTUUID="c9b8f181-03"
 ```
 
@@ -126,7 +126,7 @@ Suppose you have a partition(`/dev/sda2`) and you want to use it as a SWAP parti
 $ mkswap -L BURMILLA_SWAP /dev/sda2
 
 $ blkid
-/dev/sda1: LABEL="BURMILLA_STATE" UUID="512f212b-3130-458e-a2d1-1d601c34d4e4" TYPE="ext4" PARTUUID="9fff87e9-01"
+/dev/sda1: LABEL="RANCHER_STATE" UUID="512f212b-3130-458e-a2d1-1d601c34d4e4" TYPE="ext4" PARTUUID="9fff87e9-01"
 /dev/sda2: LABEL="BURMILLA_SWAP" UUID="772b6e76-f89c-458e-931e-10902d78d3e4" TYPE="swap" PARTUUID="9fff87e9-02"
 ```
 

--- a/content/docs/storage/custom-partition-layout.md
+++ b/content/docs/storage/custom-partition-layout.md
@@ -48,7 +48,7 @@ $ reboot
 
 > In this mode, the RANCHER_STATE partition capacity cannot exceed 3.8GiB, otherwise the bootloader may not recognize the boot disk. This is the test result on VirtualBox.
 
-### BURMILLA_BOOT
+### RANCHER_BOOT
 
 When you only use the RANCHER_STATE partition, the bootloader will be installed in the `/boot` directory.
 
@@ -74,12 +74,12 @@ Device     Boot   Start      End Sectors  Size Id Type
 /dev/sda2       2504704  7503167 4998464  2.4G 83 Linux
 /dev/sda3       7503872 10503167 2999296  1.4G 83 Linux
 
-[root@burmilla burmilla]# mkfs.ext4 -L BURMILLA_BOOT /dev/sda1
+[root@burmilla burmilla]# mkfs.ext4 -L RANCHER_BOOT /dev/sda1
 [root@burmilla burmilla]# mkfs.ext4 -L RANCHER_STATE /dev/sda2
 [root@burmilla burmilla]# mkfs.ext4 /dev/sda3
 
 [root@burmilla burmilla]# blkid
-/dev/sda1: LABEL="BURMILLA_BOOT" UUID="43baeac3-11f3-4eed-acfa-64daf66b26c8" TYPE="ext4" PARTUUID="e32b3025-01"
+/dev/sda1: LABEL="RANCHER_BOOT" UUID="43baeac3-11f3-4eed-acfa-64daf66b26c8" TYPE="ext4" PARTUUID="e32b3025-01"
 /dev/sda2: LABEL="RANCHER_STATE" UUID="16f1ecef-dbe4-42a2-87a1-611939684e0b" TYPE="ext4" PARTUUID="e32b3025-02"
 /dev/sda3: UUID="9f34e161-0eee-48f9-93de-3b7c54dea437" TYPE="ext4" PARTUUID="c9b8f181-03"
 ```
@@ -102,7 +102,7 @@ drwxr-xr-x    1 root     root        4.0K Sep 27 03:38 ..
 
 If you are not using the first partition as a BOOT partition, you need to set BOOT flag via the fdisk tool.
 
-> In this mode, the BURMILLA_BOOT partition capacity cannot exceed 3.8GiB, otherwise the bootloader may not recognize the boot disk. This is the test result on VirtualBox.
+> In this mode, the RANCHER_BOOT partition capacity cannot exceed 3.8GiB, otherwise the bootloader may not recognize the boot disk. This is the test result on VirtualBox.
 
 ### BURMILLA_OEM
 

--- a/content/docs/storage/state-partition.md
+++ b/content/docs/storage/state-partition.md
@@ -3,14 +3,14 @@ bookToc: false
 ---
 # Persistent State Partition
 
-BurmillaOS will store its state in a single partition specified by the `dev` field.  The field can be a device such as `/dev/sda1` or a logical name such `LABEL=state` or `UUID=123124`.  The default value is `LABEL=BURMILLA_STATE`.  The file system type of that partition can be set to `auto` or a specific file system type such as `ext4`.
+BurmillaOS will store its state in a single partition specified by the `dev` field.  The field can be a device such as `/dev/sda1` or a logical name such `LABEL=state` or `UUID=123124`.  The default value is `LABEL=RANCHER_STATE`.  The file system type of that partition can be set to `auto` or a specific file system type such as `ext4`.
 
 ```yaml
 #cloud-config
 rancher:
   state:
     fstype: auto
-    dev: LABEL=BURMILLA_STATE
+    dev: LABEL=RANCHER_STATE
 ```
 
 For other labels such as `BURMILLA_BOOT` and `BURMILLA_OEM` and `BURMILLA_SWAP`, please refer to [Custom partition layout](/docs/storage/custom-partition-layout).

--- a/content/docs/storage/state-partition.md
+++ b/content/docs/storage/state-partition.md
@@ -13,7 +13,7 @@ rancher:
     dev: LABEL=RANCHER_STATE
 ```
 
-For other labels such as `BURMILLA_BOOT` and `BURMILLA_OEM` and `BURMILLA_SWAP`, please refer to [Custom partition layout](/docs/storage/custom-partition-layout).
+For other labels such as `RANCHER_BOOT` and `BURMILLA_OEM` and `BURMILLA_SWAP`, please refer to [Custom partition layout](/docs/storage/custom-partition-layout).
 
 ## Autoformat
 

--- a/content/docs/system-services/custom-system-services.md
+++ b/content/docs/system-services/custom-system-services.md
@@ -164,7 +164,7 @@ Once you have your own Services repository, you can add a new service to its ind
 To create your own console images, you need to:
 
 1. install some basic tools, including an ssh daemon, sudo, and kernel module tools
-2. create `burmilla` and `docker` users and groups with UID and GID's of `1100` and `1101` respectively
+2. create `rancher` and `docker` users and groups with UID and GID's of `1100` and `1101` respectively
 3. add both users to the `docker` and `sudo` groups
 4. add both groups into the `/etc/sudoers` file to allow password-less sudo
 5. configure sshd to accept logins from users in the `docker` group, and deny `root`.

--- a/content/docs/system-services/custom-system-services.md
+++ b/content/docs/system-services/custom-system-services.md
@@ -18,7 +18,7 @@ rancher:
 
 ### Using Local Files
 
-If you already have BurmillaOS running, you can start a system service by saving a `docker-compose.yml` file at `/var/lib/burmilla/conf/`.
+If you already have BurmillaOS running, you can start a system service by saving a `docker-compose.yml` file at `/var/lib/rancher/conf/`.
 
 ```yaml
 nginxapp:
@@ -29,8 +29,8 @@ nginxapp:
 To enable a custom system service from the file location, the command must indicate the file location if saved in BurmillaOS. If the file is saved at a http(s) url, just use the http(s) url when enabling/disabling.
 
 ```bash
-# Enable the system service saved in /var/lib/burmilla/conf
-$ sudo ros service enable /var/lib/burmilla/conf/example.yml
+# Enable the system service saved in /var/lib/rancher/conf
+$ sudo ros service enable /var/lib/rancher/conf/example.yml
 # Enable a system service saved at a http(s) url
 $ sudo ros service enable https://mydomain.com/example.yml
 ```
@@ -153,7 +153,7 @@ INFO[0000] Project [os]: Project started
 ```
 
 Beware that there is an overly aggressive caching of yml files - so when you push a new yml file to your repo, you need to
-delete the files in `/var/lib/burmilla/cache`.
+delete the files in `/var/lib/rancher/cache`.
 
 The image that you specify in the service yml file needs to be pullable - either from a private registry, or on the Docker Hub.
 

--- a/content/docs/system-services/custom-system-services.md
+++ b/content/docs/system-services/custom-system-services.md
@@ -117,8 +117,8 @@ If you're building your own services in a branch on GitHub, you can push to it, 
 For example, when developing the zfs service:
 
 ```bash
-burmilla@zfs:~$ sudo ros config set rancher.repositories.zfs.url https://raw.githubusercontent.com/SvenDowideit/os-services/zfs-service
-burmilla@zfs:~$ sudo ros service list
+rancher@zfs:~$ sudo ros config set rancher.repositories.zfs.url https://raw.githubusercontent.com/SvenDowideit/os-services/zfs-service
+rancher@zfs:~$ sudo ros service list
 disabled amazon-ecs-agent
 disabled kernel-extras
 enabled  kernel-headers
@@ -130,7 +130,7 @@ disabled kernel-headers
 disabled kernel-headers-system-docker
 disabled open-vm-tools
 disabled zfs
-[burmilla@zfs ~]$ sudo ros service enable zfs
+[rancher@zfs ~]$ sudo ros service enable zfs
 Pulling zfs (zombie/zfs)...
 latest: Pulling from zombie/zfs
 b3e1c725a85f: Pull complete
@@ -143,7 +143,7 @@ d1a8c0826fbb: Pull complete
 66c2263f2388: Pull complete
 Digest: sha256:eab7b8c21fbefb55f7ee311dd236acee215cb6a5d22942844178b8c6d4e02cd9
 Status: Downloaded newer image for zombie/zfs:latest
-[burmilla@zfs ~]$ sudo ros service up zfs
+[rancher@zfs ~]$ sudo ros service up zfs
 WARN[0000] The KERNEL_VERSION variable is not set. Substituting a blank string.
 INFO[0000] Project [os]: Starting project
 INFO[0000] [0/21] [zfs]: Starting

--- a/content/docs/system-services/environment.md
+++ b/content/docs/system-services/environment.md
@@ -36,5 +36,5 @@ There is also a way to extend PATH environment variable, `PATH` or `path` can be
 ```yaml
 rancher:
   environment:
-    path: /opt/bin,/home/burmilla/bin
+    path: /opt/bin,/home/rancher/bin
 ```

--- a/content/docs/system-services/system-docker-volumes.md
+++ b/content/docs/system-services/system-docker-volumes.md
@@ -67,9 +67,9 @@ Provides necessary persistent directories, used by system services:
 /lib/modules
 /run
 /usr/share/ros
-/var/lib/burmilla/cache
-/var/lib/burmilla/conf
-/var/lib/burmilla
+/var/lib/rancher/cache
+/var/lib/rancher/conf
+/var/lib/rancher
 /var/log
 /var/run
 ```


### PR DESCRIPTION
Hi, I recently heavily searched docs and still it has so many incorrect "burmilla" exists.

It was a bit frustrating and  I tried to fix those step by step.
I hope I've eliminated all incorrect "burmilla"s.

Could you confirm these commits?

p.s.
I think we can list up unmodified "burmilla"s remains in the repo with the command below.
```sh
$ egrep --color=always 'burmilla[^/o]' **/*.md | egrep -v '(tar\.gz|github)'
```