### PR TITLE
Corrections to documentation by Claude Code

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -32,6 +32,21 @@ We created this separation not only for the security benefits, but also to make 
 
 ![How it works](https://raw.githubusercontent.com/burmilla/burmilla.github.io/master/static/images/howitworks.png)
 
+## Supported Use Cases
+
+BurmillaOS is built around Docker and is best suited for the following workloads:
+
+- Standalone Docker containers (`docker run` / `docker create`)
+- Multi-container applications (`docker-compose`)
+- Docker Swarm mode (`docker stack deploy` / `docker service`)
+
+The following use cases are **not** the focus of BurmillaOS and issues related to them are considered low priority:
+
+- Kubernetes / K3s (consider [k3OS](https://github.com/rancher/k3os) for those use cases)
+- Rancher 2.x (requires Kubernetes)
+
+Users are free to attempt these use cases, but they are not officially supported.
+
 ## Running BurmillaOS
 
 To get started with BurmillaOS, head over to our [Quick Start Guide](/docs/quick-start-guide).

--- a/content/docs/faqs.md
+++ b/content/docs/faqs.md
@@ -23,7 +23,7 @@ Command | Description
 Assuming your EC2 instance with BurmillaOS with more disk space than what's being read, run the following command to extend the disk size. This allows BurmillaOS to see the disk size.
 
 ```
-$ docker run --privileged --rm --it debian:jessie resize2fs /dev/xvda1
+$ docker run --privileged --rm -it debian:jessie resize2fs /dev/xvda1
 ```
 
 `xvda1` should be the right disk for your own setup. In the future, we will be trying to create a system service that would automatically do this on boot in AWS.

--- a/content/docs/installation/cloud/digital-ocean.md
+++ b/content/docs/installation/cloud/digital-ocean.md
@@ -40,14 +40,14 @@ write_files:
 
       export curlimage=appropriate/curl
       export jqimage=stedolan/jq
-      export burmilla_version=v2.2.2
+      export rancher_version=v2.9.3
 
-      for image in $curlimage $jqimage "burmilla/burmilla:${burmilla_version}"; do
+      for image in $curlimage $jqimage "rancher/rancher:${rancher_version}"; do
         until docker inspect $image > /dev/null 2>&1; do
           docker pull $image
           sleep 2
         done
       done
 
-      docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -v /opt/rancher:/var/lib/rancher burmilla/burmilla:${burmilla_version}
+      docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -v /opt/rancher:/var/lib/rancher rancher/rancher:${rancher_version}
 ```

--- a/content/docs/installation/cloud/openstack.md
+++ b/content/docs/installation/cloud/openstack.md
@@ -4,6 +4,6 @@ bookToc: false
 ---
 # OpenStack
 
-BurmillaOS releases include an Openstack image that can be found on our [releases page](https://github.com/burmilla/os/releases). The image format is [QCOW3](https://wiki.qemu.org/Features/Qcow3#Fully_QCOW2_backwards-compatible_feature_set) that is backward compatible with QCOW2.
+Because the BurmillaOS community is small, we do not currently publish a dedicated OpenStack image in our [releases](https://github.com/burmilla/os/releases). You can upload the `rootfs.tar.gz` artifact or build a custom QCOW2 image from the BurmillaOS ISO.
 
-When launching an instance using the image, you must enable **Advanced Options** -> **Configuration Drive** and in order to use a [cloud-config](/docs/configuration/base/#cloud-config) file.
+When launching an instance using a custom image, enable **Advanced Options** -> **Configuration Drive** in order to use a [cloud-config](/docs/configuration/base/#cloud-config) file.

--- a/content/docs/installation/server/install-to-disk.md
+++ b/content/docs/installation/server/install-to-disk.md
@@ -1,6 +1,6 @@
 # Installing to Disk
 
-BurmillaOS comes with a simple installer that will install BurmillaOS on a given target disk. To install BurmillaOS on a new disk, you can use the `ros install` command. Before installing, you'll need to have already [booted BurmillaOS from ISO](/docs/installation/workstation//boot-from-iso). Please be sure to pick the `burmillaos.iso` from our release [page](https://github.com/burmilla/os/releases).
+BurmillaOS comes with a simple installer that will install BurmillaOS on a given target disk. To install BurmillaOS on a new disk, you can use the `ros install` command. Before installing, you'll need to have already [booted BurmillaOS from ISO](/docs/installation/workstation/boot-from-iso). Please be sure to pick the `burmillaos.iso` from our release [page](https://github.com/burmilla/os/releases).
 
 ## Installing BurmillaOS
 

--- a/content/docs/installation/server/install-to-disk.md
+++ b/content/docs/installation/server/install-to-disk.md
@@ -75,8 +75,6 @@ Alternatively, you can set the installer image to any image in System Docker to 
 
 ### Caching Images
 
-_Available as of RancherOS v1.5.3_
-
 Some configurations included in `cloud-config` require images to be downloaded from Docker to start. After installation, these images are downloaded automatically by BurmillaOS when booting. An example of these configurations are:
 
 - rancher.services_include

--- a/content/docs/quick-start-guide.md
+++ b/content/docs/quick-start-guide.md
@@ -3,11 +3,13 @@ weight: 1
 ---
 # Quick Start
 
-If you have a specific BurmillaOS [machine requirements](/#hardware-requirements), please check out our [guides on running BurmillaOS](/docs/installation). With the rest of this guide, we'll start up a BurmillaOS using [Docker machine](/docs/installation/workstation/docker-machine) and show you some of what BurmillaOS can do.
+If you have a specific BurmillaOS [machine requirements](/#hardware-requirements), please check out our [guides on running BurmillaOS](/docs/installation). With the rest of this guide, we'll show you some of what BurmillaOS can do.
 
-## Launching BurmillaOS using Docker Machine
+## Launching BurmillaOS
 
-Before moving forward, you'll need to have [Docker Machine](https://docs.docker.com/machine/) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads) installed. Once you have VirtualBox and Docker Machine installed, it's just one command to get BurmillaOS running.
+The recommended way to get started is to [boot BurmillaOS from ISO](/docs/installation/workstation/boot-from-iso) using VirtualBox or another hypervisor.
+
+Alternatively, you can use [Docker Machine](/docs/installation/workstation/docker-machine) to launch a BurmillaOS VM. Note that the original Docker Machine project was retired by Docker Inc., but a maintained fork is available at [github.com/rancher/machine](https://github.com/rancher/machine).
 
 ```bash
 $ docker-machine create -d virtualbox \
@@ -16,9 +18,7 @@ $ docker-machine create -d virtualbox \
         <MACHINE-NAME>
 ```
 
-That's it! You're up and running a BurmillaOS instance.
-
-To log into the instance, just use the `docker-machine` command.
+To log into a Docker Machine instance, use:
 
 ```bash
 $ docker-machine ssh <MACHINE-NAME>

--- a/content/docs/releases.md
+++ b/content/docs/releases.md
@@ -8,13 +8,18 @@ weight: 12
 The following is a list of the versions of the operating system in their different branches:
 
 #### Stable
-- [v2.0.0](https://github.com/burmilla/os/releases/tag/v2.0.0) | 2024-03-05
-
-#### Old stable
-- [v1.9.7-rc1](https://github.com/burmilla/os/releases/tag/v1.9.7-rc1) | 2023-02-01
-- [v1.9.6](https://github.com/burmilla/os/releases/tag/v1.9.6) | 2023-01-02
+- [v2.0.5](https://github.com/burmilla/os/releases/tag/v2.0.5) | 2025-11-14
 
 #### Testing
+- [v2.0.6-rc1](https://github.com/burmilla/os/releases/tag/v2.0.6-rc1) | 2026-01-21
+
+#### Old stable
+- [v2.0.4](https://github.com/burmilla/os/releases/tag/v2.0.4) | 2025-07-14
+- [v2.0.3](https://github.com/burmilla/os/releases/tag/v2.0.3) | 2025-05-12
+- [v2.0.2](https://github.com/burmilla/os/releases/tag/v2.0.2) | 2025-01-14
+- [v2.0.1](https://github.com/burmilla/os/releases/tag/v2.0.1) | 2024-04-12
+- [v2.0.0](https://github.com/burmilla/os/releases/tag/v2.0.0) | 2024-03-05
+- [v1.9.6](https://github.com/burmilla/os/releases/tag/v1.9.6) | 2023-01-02
 
 #### Archived
 - [v1.9.5](https://github.com/burmilla/os/releases/tag/v1.9.5) | 2022-09-15


### PR DESCRIPTION
Testing new tooling here. I asked Claude Code to read all issues BurmillaOS issues with [documentation](https://github.com/burmilla/os/issues?q=is%3Aissue%20label%3Adocumentation) label and fix them in way that each issue gets own commit.

Here is also summary from Claude:
 ```
  ┌─────────┬───────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Commit  │   Issue   │                                                      Fix                                                       │
  ├─────────┼───────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 57dbe2a │ #192      │ Updated releases.md: added v2.0.1–v2.0.5 (stable), v2.0.6-rc1 (testing), removed v1.9.7-rc1 which was a        │
  │         │           │ pre-release that never became stable                                                                           │
  ├─────────┼───────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 019ed77 │ #191      │ Updated quick-start-guide.md: noted Docker Machine was retired by Docker Inc., Rancher fork is available, made │
  │         │           │  Boot from ISO the recommended method                                                                          │
  ├─────────┼───────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 4ef88ee │ #22       │ Added "Supported Use Cases" section to _index.md: Docker/Compose/Swarm supported; Kubernetes/Rancher 2.x are   │
  │         │           │ out of scope                                                                                                   │
  ├─────────┼───────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 555decc │ #74       │ Fixed openstack.md: removed false claim that releases include an OpenStack image (none exists)                 │
  ├─────────┼───────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 871bf91 │ #179      │ Fixed double-slash URL in install-to-disk.md                                                                   │
  ├─────────┼───────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 57bcf68 │ #179      │ Fixed digital-ocean.md: PR #38 had fixed the SSH user but left burmilla/burmilla (non-existent image) and      │
  │         │           │ v2.2.2 (non-existent version) — restored to rancher/rancher                                                    │
  ├─────────┼───────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 068148a │ #179      │ Removed obsolete "Available as of RancherOS v1.5.3" note from install-to-disk.md                               │
  ├─────────┼───────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 40d57be │ (general) │ Fixed invalid --it flag (should be -it) in faqs.md Docker command                                              │
  └─────────┴───────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```
